### PR TITLE
Say something useful about comma-first

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -989,5 +989,6 @@ Projects _must_ include some form of unit, reference, implementation or function
 
 Any project that cites this document as its base style guide will not accept comma first code formatting unless explicitly specified otherwise.
 
-See: https://mail.mozilla.org/pipermail/es-discuss/2011-September/016805.html
-Notable: "That is horrible, and a reason to reject comma first.", "comma-first still is to be avoided"
+Recommended reading:
+	* https://gist.github.com/357981 (discussion)
+	* http://inimino.org/~inimino/blog/javascript_whitespace


### PR DESCRIPTION
This change removes the reference to the mozilla.org thread and adds meaningful reading recommendations. The example in that link isn't really used or encouraged by anyone:

```
var middleware = [ context,
                 , csrf
                 , xsite
                 , head
                 , considtional
                 , error
                 ] // wat
```

I don't want to get into a discussion about the style here, but the argument is that it's hard to spot the errant comma on the first line. It's just as hard as it is to notice a missing comma in standard style:

```
var middleware = [
  context,
  csrf,
  xsite
  head,
  conditional,
  error
]
```

And this is actual comma-first style (with an error):

```
var middleware = [
    context
  , csrf
    xsite
  , head
  , conditional
  , error
]
```

It's perfectly reasonable to mix the recommendations in this document with comma-first or even no-semicolon styles (except that 4-char spacing looks better with it), and be respectful for other's choices. The links point to relevant and civilized discussions on the subject.
