### PR TITLE
remove link to rebeccamurphey.com

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The following should be considered 1) incomplete, and 2) *REQUIRED READING*. I d
 
  * [Eloquent JavaScript](http://eloquentjavascript.net/)
  * [JavaScript, JavaScript](http://javascriptweblog.wordpress.com/)
- * [Rebecca Murphey](http://www.rebeccamurphey.com/) or [Adventures in JavaScript Development](http://rmurphey.com/)
+ * [Adventures in JavaScript Development](http://rmurphey.com/)
  * [Perfection Kills](http://perfectionkills.com/)
  * [Douglas Crockford's Wrrrld Wide Web](http://www.crockford.com)
 


### PR DESCRIPTION
Everything's at rmurphey.com now and rebeccamurphey.com just redirects.
