### PR TITLE
added bitwise type conversion notes with NaN and nonnumerical values

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@
 * Stephan Lindauer [@stephanlindauer](http://twitter.com/stephanlindauer), [github](https://github.com/stephanlindauer)
 * Thomas P [@dragon5689](https://twitter.com/dragon5689) [github](https://github.com/dragon5689)
 * Yotam Ofek [@yotamofek](https://twitter.com/yotamofek) [github](https://github.com/yotamofek)
+* Frankie Bagnardi [github](https://github.com/brigand)
 
 
 
@@ -637,6 +638,8 @@ The following sections outline a _reasonable_ style guide for modern JavaScript 
     num >> 0;
 
     num >>> 0;
+    
+    num | 0;
 
     // All result in 2
 
@@ -652,6 +655,8 @@ The following sections outline a _reasonable_ style guide for modern JavaScript 
     ~~neg;
 
     neg >> 0;
+    
+    neg | 0;
 
     // All result in -2
     // However...
@@ -660,8 +665,20 @@ The following sections outline a _reasonable_ style guide for modern JavaScript 
 
     // Will result in 4294967294
 
+    
+    // and nonnumerical values...
 
-
+    parseInt("foobar");
+    
+    // is NaN, but these are all 0
+    
+    "Infinity" | 0;
+    
+    "-Infinity" ^ 0;
+    
+    Infinity >>> 0;
+    
+    NaN | 0;
 
     ```
 


### PR DESCRIPTION
When `isNaN(parseInt(x))`, then `(x | 0) !== parseInt(x, 10)`.
