### PR TITLE
Correct link for plato

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@
 ### Code Quality Tools, Resources & References
 
  * [JavaScript Plugin](http://docs.codehaus.org/display/SONAR/JavaScript+Plugin) for [Sonar](http://www.sonarsource.org/)
- * [Plato](https://github.com/jsoverson/plato)
+ * [Plato](https://github.com/es-analysis/plato)
  * [jsPerf](http://jsperf.com/)
  * [jsFiddle](http://jsfiddle.net/)
  * [jsbin](http://jsbin.com/)


### PR DESCRIPTION
As stated in the original repository's [readme](https://github.com/jsoverson/plato) it is moved to the new repository
