### PR TITLE
Add Hound to list of resources

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@
  * [eslint](http://eslint.org/)
  * [jscs](https://www.npmjs.org/package/jscs)
  * [Editorconfig](http://editorconfig.org/)
+ * [Hound](https://houndci.com)
 
 ## Get Smart
 


### PR DESCRIPTION
Hound is free for open source repos. It was recently enabled on the Bootstrap project, for instance.

It comments in-line on GitHub pull requests for style violations. It is essentially CI / hosted JSHint at the moment. It can be configured by `.jshintrc` files placed anywhere in the repo.

There have been requests for ESLint and JSCS options for Hound. Aside from adding Hound to this list, I'd love this group's opinion on those tools.

It looks like the JavaScript community is evolving JSHint to be focused on a stricter subset of rules that can be treated as binary outcomes, and therefore included as part of Grunt `test` tasks in the Travis/Circle/etc. CI processes, failing the build when violations are found?

The more stylistic stuff appears to be moving to JSCS, and can be treated more as suggestions, not binary outcomes?

I'm still understanding how ESLint and JSLint fit into the ecosystem.

Hound has historically been useful as a commenting system in scenarios where the linters can produce those non-binary outcomes, or may occasionally have false positives. The comment provides an opportunity for the author to decide whether to ignore or not.

There is a `fail_on_violations: true` configuration option to have Hound set the status of the GitHub pull request to failed if failures are found, so it can be used more strictly as CI if desired.

Would love any thoughts you might have about the popular JS linters, and their typical use and "strictness". My current understanding is:

* JSHint - can reliably fail the build with "out of the box" defaults
* ESLint - for ES projects, can reliably fail the build with "out of the box" defaults
* JSCS - not meant to reliably fail the build with "out of the box" defaults
* JSLint - ?