### PR TITLE
add contributor and zh-tw translation to the main readme.

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -27,3 +27,4 @@
 * Aleksandr Filatov [@greybax](http://twitter.com/greybax), [github](https://github.com/greybax)
 * Duc Nguyen [@ducntq](https://twitter.com/ducntq), [github](https://github.com/ducntq)
 * James Young [@jamsyoung](http://twitter.com/jamsyoung), [github](https://github.com/jamsyoung)
+* Calvin Jeng [@l0ckys](http://twitter.com/l0ckys), [github](https://github.com/lockys)

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@
 * Aleksandr Filatov [@greybax](http://twitter.com/greybax), [github](https://github.com/greybax)
 * Duc Nguyen [@ducntq](https://twitter.com/ducntq), [github](https://github.com/ducntq)
 * James Young [@jamsyoung](http://twitter.com/jamsyoung), [github](https://github.com/jamsyoung)
-
+* Hao-Wei Jeng [@l0ckys](http://twitter.com/l0ckys), [github](https://github.com/lockys)  
 
 
 ## All code in any code-base should look like a single person typed it, no matter how many people contributed.
@@ -65,7 +65,7 @@
 * [简体中文](https://github.com/rwldrn/idiomatic.js/tree/master/translations/zh_CN)
 * [Serbian - cyrilic alphabet](https://github.com/rwldrn/idiomatic.js/tree/master/translations/ср_СР)
 * [Serbian - latin alphabet](https://github.com/rwldrn/idiomatic.js/tree/master/translations/sr_SR)
-
+* [繁體中文](https://github.com/rwaldron/idiomatic.js/tree/master/translations/zh_TW)  
 
 ## Important, Non-Idiomatic Stuff:
 


### PR DESCRIPTION
Dear author and collaborators,

I have translated `idiomatic.js` into Traditional Chinese about serial months ago and it has been merged.
But the main `readme.md` file does not include the Traditional Chinese(繁體中文) in the [list](https://github.com/rwaldron/idiomatic.js#translations) of translation.

So, the people may not know that there is a Traditional Chinese version of `idiomatic.js`.
Please consider to add it.

Thanks :)