### PR TITLE
Adding Jest to the JavaScript testing frameworks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,7 @@ Projects _must_ include some form of unit, reference, implementation or function
  * [Buster.js](http://busterjs.org/)
  * [Sinon.js](http://sinonjs.org/)
  * [Tape](https://github.com/substack/tape)
+ * [Jest](https://facebook.github.io/jest/)
 
 ## Table of Contents
 


### PR DESCRIPTION
Jest is currently missing among the listed testing frameworks, so I added it.