### PR TITLE
[fr_FR] Changed the word "coercion" to "conversion"

### DIFF
--- a/translations/fr_FR/readme.md
+++ b/translations/fr_FR/readme.md
@@ -433,7 +433,7 @@ Les sections suivantes décrivent un guide de style _raisonable_ pour tout déve
 	JavaScript est un langage typé dynamiquement - ce qui peut être votre meilleur ami comme votre pire ennemi : respectez donc les 'types', en appliquant les règles ci-dessus.
 
 
-	3.B Coercion de type
+	3.B Conversion de type
 
 	Considérons les implications de ce qui suit...
 
@@ -457,7 +457,8 @@ Les sections suivantes décrivent un guide de style _raisonable_ pour tout déve
 	// "number"
 	...
 
-	// Quelque part plus loin dans votre code, vous devez mettre à jour `foo`
+	// Quelque part plus loin dans votre code, vous devez mettre 
+	jour `foo`
 	// avec une nouvelle valeur issue de l'élément 'input'
 
 	foo = document.getElementById("foo-input").value;
@@ -475,7 +476,7 @@ Les sections suivantes décrivent un guide de style _raisonable_ pour tout déve
 
 	// 3.B.1.2
 
-	// Vous pouvez vous prémunir de ce problème en utilisant la coercion de type de l'opérateur unaire + ou - :
+	// Vous pouvez vous prémunir de ce problème en utilisant la conversion de type avec l'opérateur unaire + ou - :
 
 	foo = +document.getElementById("foo-input").value;
 	      ^ opérateur unaire + convertissant à sa droite l'opérande en "number"
@@ -492,7 +493,7 @@ Les sections suivantes décrivent un guide de style _raisonable_ pour tout déve
 	// `important()` sera évalué
 	```
 
-	Voici quelques cas courants de coercion :
+	Voici quelques cas courants de conversion :
 
 
 	```javascript
@@ -643,7 +644,7 @@ Les sections suivantes décrivent un guide de style _raisonable_ pour tout déve
 	// Plutôt que d'utiliser l'expression suivante :
 	if ( foo === false ) ...
 
-	// ...utilisez la négation et la coercion de l'évaluation de la vérité :
+	// ...utilisez la négation et la conversion de l'évaluation de la vérité :
 	if ( !foo ) ...
 
 	// ...Soyez prudent, cela correspondra aux valeurs suivantes : 0, "", null, undefined, NaN
@@ -656,7 +657,7 @@ Les sections suivantes décrivent un guide de style _raisonable_ pour tout déve
 	// Plutôt que d'utiliser l'expression suivante :
 	if ( foo === null || foo === undefined ) ...
 
-	// ...bénéficiez de la coercion de type ==, comme suit :
+	// ...bénéficiez de la conversion de type ==, comme suit :
 	if ( foo == null ) ...
 
 	// Souvenez-vous, utiliser == vérifiera une égalité avec `null` et `null` & `undefined`
@@ -669,16 +670,16 @@ Les sections suivantes décrivent un guide de style _raisonable_ pour tout déve
 	```javascript
 
 	// 4.2.1
-	// Coercion de Type coercion et remarques
+	// Conversion de type et remarques
 
 	Preferez `===` à la place de `==` (à moins que le cas de test ne requiert la perte d'évaluation de type)
 
-	=== n'effectue pas de coercion de type, ce qui signifie que :
+	=== n'effectue pas de conversion de type, ce qui signifie que :
 
 	"1" === 1;
 	// faux
 
-	== effectue la coercion de type, ce qui signifie que :
+	== effectue la conversion de type, ce qui signifie que :
 
 	"1" == 1;
 	// vrai


### PR DESCRIPTION
The therm "coercion" does not exist in French. While the equivalent could be "coercition", the word "conversion" is the most commonly used.