### PR TITLE
fix(readme.md): sonar death link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@
 
 ### Code Quality Tools, Resources & References
 
- * [JavaScript Plugin](http://docs.codehaus.org/display/SONAR/JavaScript+Plugin) for [Sonar](http://www.sonarsource.org/)
+ * [SonarQube](https://www.sonarqube.org/)
  * [Plato](https://github.com/es-analysis/plato)
  * [jsPerf](http://jsperf.com/)
  * [jsFiddle](http://jsfiddle.net/)


### PR DESCRIPTION
`codehaus.org` domain not exist anymore and redirected to `sonarqube.org` and support javascript 