### PR TITLE
fixing broken link in readme.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@
 
 The following should be considered 1) incomplete, and 2) *REQUIRED READING*. I don't always agree with the style written by the authors below, but one thing is certain: They are consistent. Furthermore, these are authorities on the language.
 
- * [Baseline For Front End Developers: 2015](http://rmurphey.com/blog/2015/03/23/a-baseline-for-front-end-developers-2015/)
+ * [Baseline For Front End Developers: 2015](https://rmurphey.com/posts/a-baseline-for-front-end-developers-2015/)
  * [Eloquent JavaScript](http://eloquentjavascript.net/)
  * [JavaScript, JavaScript](http://javascriptweblog.wordpress.com/)
  * [Adventures in JavaScript Development](http://rmurphey.com/)


### PR DESCRIPTION
The link in the main readme about " Baseline for Front-End [JS] Developers, 2015" has changed. I tracked down the website and, with a little search, I've found the correct link. With this PR, I update it.