### PR TITLE
replaced #foo with .foo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -925,7 +925,7 @@ The following sections outline a _reasonable_ style guide for modern JavaScript 
     function q(s) {
       return document.querySelectorAll(s);
     }
-    var i,a=[],els=q("#foo");
+    var i,a=[],els=q(".foo");
     for(i=0;i<els.length;i++){a.push(els[i]);}
     ```
 
@@ -944,7 +944,7 @@ The following sections outline a _reasonable_ style guide for modern JavaScript 
 
     var idx = 0,
       elements = [],
-      matches = query("#foo"),
+      matches = query(".foo"),
       length = matches.length;
 
     for ( ; idx < length; idx++ ) {


### PR DESCRIPTION
Since it is not recommended to use the same ID for multiple HTML elements on the same page, and since the purpose of an ID attribute is to uniquely identify a single element within an HTML document. Using the same ID for multiple elements would violate this principle and can lead to various issues. So considering this rule, the `query()` function will return one element with the give id `#foo`, which means that the `for` loop will iterate once. So I've changes the selector to be `.foo` (class selector) so we may get more than one element with the same class name "foo".